### PR TITLE
disksize(): Treat registers as unsigned integers

### DIFF
--- a/dosfetch.pas
+++ b/dosfetch.pas
@@ -70,7 +70,7 @@ begin
 end;
 
 procedure disksize(disk: byte);
-var a, b, c, d : integer;
+var a, b, c, d : word;
    total, free : longint;
 begin
    asm


### PR DESCRIPTION
This should fix some of the negative numbers that we're seeing.

(Note that `longint` is still signed. Free Pascal knows `longword`, but I don’t think that Turbo Pascal does. Not sure how one could fix this.)